### PR TITLE
chore(deps): update uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -516,7 +516,7 @@ wheels = [
 
 [[package]]
 name = "pkg-ext"
-version = "0.3.2"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ask-shell" },
@@ -525,9 +525,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "zero-3rdparty" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/57/fd137f69dc656b1bf18516501a81ff8e10537b367951bf62ca16f2f3ae91/pkg_ext-0.3.2.tar.gz", hash = "sha256:8fffedd43feb32b8d1eea9aa90282c78bbf2e91f6d9491b343265f63b317a843", size = 76327, upload-time = "2026-02-06T06:11:20.389Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/09/6b048a43051b4c4cc6fbdfd398b50327b538721ffff366c2e53461a06322/pkg_ext-0.3.3.tar.gz", hash = "sha256:c63c4590b3eafb682d7997d1d8f907f1fb160898611fd13300f9016bd3a5548a", size = 76328, upload-time = "2026-02-06T10:51:09.517Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/8ce3ce022747ec62c8af4734243379ea9afebfa265c562ea465f47bcfe34/pkg_ext-0.3.2-py3-none-any.whl", hash = "sha256:6733aac02dc0bc6836bfeecd1b264db6a5ecb802aee914af5e95a3ab82ae68e9", size = 110308, upload-time = "2026-02-06T06:11:19.071Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/ccf5316b2b05971e39dfc02dec3bbd26bda1c35bf239d5c348359dc612a6/pkg_ext-0.3.3-py3-none-any.whl", hash = "sha256:006609865a8f12f2fedb4a3644b14c70c8458c1347a6e72d5b603905b007c90c", size = 110309, upload-time = "2026-02-06T10:51:08.298Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated dependency update.

## Command Output

```
Processing path-sync...
Fetching origin and resetting to main
Fetching origin
Checking out main
Deleted existing local branch: deps/uv-lock-update
Creating fresh branch: deps/uv-lock-update
Running: uv lock --upgrade
[uv] Resolved 65 packages in 896ms
[uv] Updated zero-3rdparty v0.104.0 -> v0.104.1
Committed: chore(deps): update uv.lock
Running: uv sync
[uv] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
[uv] Resolved 65 packages in 5ms
[uv]    Building path-sync @ file:///private/tmp/path-sync-deps/path-sync
[uv]       Built path-sync @ file:///private/tmp/path-sync-deps/path-sync
[uv] Prepared 1 package in 765ms
[uv] Uninstalled 13 packages in 136ms
[uv] Installed 2 packages in 4ms
[uv]  - ask-shell==0.3.1
[uv]  - model-lib==0.102.0
[uv]  ~ path-sync==0.5.0 (from file:///private/tmp/path-sync-deps/path-sync)
[uv]  - pkg-ext==0.3.2
[uv]  - platformdirs==4.5.1
[uv]  - prompt-toolkit==3.0.52
[uv]  - pydantic-settings==2.12.0
[uv]  - python-dotenv==1.2.1
[uv]  - questionary==2.1.1
[uv]  - tomli-w==1.1.0
[uv]  - tomlkit==0.14.0
[uv]  - wcwidth==0.5.3
[uv]  - zero-3rdparty==0.104.0
[uv]  + zero-3rdparty==0.104.1
Running: just fmt
[just] 33 files left unchanged
[just] uv run ruff format .
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Running: just test
[just] ============================= test session starts ==============================
[just] platform darwin -- Python 3.14.0, pytest-9.0.2, pluggy-1.6.0 -- /private/tmp/path-sync-deps/path-sync/.venv/bin/python
[just] cachedir: .pytest_cache
[just] rootdir: /private/tmp/path-sync-deps/path-sync
[just] configfile: pyproject.toml
[just] plugins: datadir-1.8.0, asyncio-1.3.0, regressions-2.9.1, cov-7.0.0
[just] asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
[just] collecting ... collected 66 items
[just] 
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_no_changes_skips 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:142 Processing test-repo...
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:152 test-repo: No changes, skipping
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_update_fails_returns_skipped 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:142 Processing test-repo...
[just] WARNING  path_sync._internal.cmd_dep_update:cmd_dep_update.py:148 test-repo: Update failed with exit code 1
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_changes_with_skip_verify_passes 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:142 Processing test-repo...
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_verify_runs_when_changes_present 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:142 Processing test-repo...
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_run_updates_success_returns_none PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_run_updates_failure_returns_step_failure PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_verify_steps_all_pass PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_verify_step_fails_with_skip_strategy PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_verify_step_fails_with_fail_strategy PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_verify_step_fails_with_warn_strategy_continues PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_verify_step_with_commit_stages_and_commits PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_verify_per_step_on_fail_overrides_verify_level PASSED
[just] path_sync/_internal/log_capture_test.py::test_capture_log_captures_logger_output 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync.test:log_capture_test.py:12 first message
[just] INFO     path_sync.test:log_capture_test.py:13 second message
[just] PASSED
[just] path_sync/_internal/log_capture_test.py::test_capture_log_read_after_flush_includes_all 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync.test2:log_capture_test.py:24 before flush
[just] INFO     path_sync.test2:log_capture_test.py:26 after first read
[just] PASSED
[just] path_sync/_internal/models_dep_test.py::test_dep_config_parsing PASSED
[just] path_sync/_internal/models_dep_test.py::test_dep_config_from_yaml PASSED
[just] path_sync/_internal/models_dep_test.py::test_resolve_dep_config_path PASSED
[just] path_sync/_internal/models_dep_test.py::test_load_destinations_with_include_filter PASSED
[just] path_sync/_internal/models_dep_test.py::test_load_destinations_with_exclude_filter PASSED
[just] path_sync/cmd_copy_test.py::test_sync_single_file 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:427 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1289/test_sync_single_file0/dest/out.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_skips_opted_out_file 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:413 Skipping /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1289/test_sync_skips_opted_out_file0/dest/file.py (header removed - opted out)
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_force_overwrite_adds_header_when_content_matches 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:427 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1289/test_force_overwrite_adds_head0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_cleanup_orphans 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:472 Deleted orphan: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1289/test_cleanup_orphans0/dest/orphan.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_with_sections_replaces_managed 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:427 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1289/test_sync_with_sections_replac0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_with_sections_skip PASSED
[just] path_sync/cmd_copy_test.py::test_ensure_dest_repo_dry_run_errors_if_missing PASSED
[just] path_sync/cmd_copy_test.py::test_copy_options_defaults PASSED
[just] path_sync/cmd_copy_test.py::test_source_with_header_no_duplicate 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:427 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1289/test_source_with_header_no_dup0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_replace_no_header 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:427 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1289/test_file_mode_replace_no_head0/dest/LICENSE
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_replace_skips_unchanged PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_scaffold_creates_new 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:427 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1289/test_file_mode_scaffold_create0/dest/.gitignore
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_scaffold_skips_existing PASSED
[just] path_sync/header_test.py::test_header_generation PASSED
[just] path_sync/header_test.py::test_has_header_matches_any_config_name PASSED
[just] path_sync/header_test.py::test_add_remove_header PASSED
[just] path_sync/header_test.py::test_add_header_extensionless PASSED
[just] path_sync/header_test.py::test_file_has_header PASSED
[just] path_sync/models_test.py::test_path_mapping_resolved PASSED
[just] path_sync/models_test.py::test_resolve_config_path PASSED
[just] path_sync/models_test.py::test_find_repo_root PASSED
[just] path_sync/models_test.py::test_src_config_find_destination PASSED
[just] path_sync/models_test.py::test_destination_skip_sections PASSED
[just] path_sync/models_test.py::test_destination_skip_file_patterns PASSED
[just] path_sync/models_test.py::test_pr_defaults_format_body PASSED
[just] path_sync/models_test.py::test_pr_defaults_format_body_extracts_repo_name PASSED
[just] path_sync/models_test.py::test_path_mapping_is_excluded PASSED
[just] path_sync/sections_test.py::test_parse_sections PASSED
[just] path_sync/sections_test.py::test_parse_sections_no_markers PASSED
[just] path_sync/sections_test.py::test_parse_sections_nested_error PASSED
[just] path_sync/sections_test.py::test_parse_sections_unclosed_error PASSED
[just] path_sync/sections_test.py::test_parse_sections_standalone_ok_edit PASSED
[just] path_sync/sections_test.py::test_has_sections PASSED
[just] path_sync/sections_test.py::test_wrap_in_default_section PASSED
[just] path_sync/sections_test.py::test_extract_sections PASSED
[just] path_sync/sections_test.py::test_replace_sections_updates_content PASSED
[just] path_sync/sections_test.py::test_replace_sections_preserves_ok_edit PASSED
[just] path_sync/sections_test.py::test_replace_sections_skip PASSED
[just] path_sync/sections_test.py::test_replace_sections_adds_new PASSED
[just] path_sync/sections_test.py::test_replace_sections_keeps_dest_only PASSED
[just] path_sync/sections_test.py::test_markdown_sections PASSED
[just] path_sync/validation_test.py::test_modify_ok_edit_passes PASSED
[just] path_sync/validation_test.py::test_modify_do_not_edit_fails PASSED
[just] path_sync/validation_test.py::test_skip_section_passes PASSED
[just] path_sync/validation_test.py::test_section_removed_warns_not_fails 
[just] -------------------------------- live log call ---------------------------------
[just] WARNING  path_sync._internal.validation:validation.py:61 Section 'standard' removed from test.py, consider updating src.yaml
[just] PASSED
[just] path_sync/validation_test.py::test_no_sections_full_file_comparison PASSED
[just] path_sync/validation_test.py::test_parse_skip_sections PASSED
[just] 
[just] ============================== 66 passed in 1.09s ==============================
[just] uv run pytest
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Running: just pkg-pre-change --full
[just] error: Justfile does not contain recipe `--full`
```

---
## Verification Issues

- `just pkg-pre-change --full` failed (exit code 1, strategy: warn)