### PR TITLE
fix: ignore submodule dirty state and reduce token scope for PR updates

### DIFF
--- a/.changelog/000.yaml
+++ b/.changelog/000.yaml
@@ -1,7 +1,0 @@
-name: __ROOT__
-ts: 2026-02-09 09:00:30.292898+00:00
-type: fix
-author: Espen Albert
-changelog_message: 'fix: ignore submodule dirty state in has_changes and commit_changes'
-message: 'fix: ignore submodule dirty state in has_changes and commit_changes'
-short_sha: 007dcf

--- a/.changelog/015.yaml
+++ b/.changelog/015.yaml
@@ -1,0 +1,7 @@
+name: __ROOT__
+ts: 2026-02-09 09:00:30.292898+00:00
+type: fix
+author: Espen Albert
+changelog_message: 'fix: ignore submodule dirty state and reduce token scope for PR updates'
+message: 'fix: ignore submodule dirty state and reduce token scope for PR updates'
+short_sha: 007dcf

--- a/path_sync/_internal/git_ops.py
+++ b/path_sync/_internal/git_ops.py
@@ -124,7 +124,7 @@ def stage_and_commit(repo: Repo, add_paths: list[str], message: str) -> bool:
         repo.git.add(path)
     for path in exclude:
         repo.git.reset("HEAD", "--", path)
-    if not repo.is_dirty(index=True):
+    if not repo.is_dirty(index=True, submodules=False):
         return False
     _ensure_git_user(repo)
     repo.git.commit("-m", message)


### PR DESCRIPTION
## Summary

- Fix `has_changes()` and `commit_changes()` to ignore submodule dirty state (`submodules=False`) which caused false-positive change detection when repos contain submodules
- Refactor `update_pr_body()` to use GitHub REST API (`gh api PATCH`) instead of `gh pr edit`, reducing required token permissions from `repo` + `read:org` to just `repo` scope

## Changes

- `has_changes()`: add `submodules=False` to `is_dirty()`
- `commit_changes()`: add `submodules=False` to `is_dirty()`
- `update_pr_body()`: replace `gh pr edit` with `gh api PATCH repos/{owner}/{repo}/pulls/{number}`
- Extract `_get_repo_full_name()` and `_get_pr_number()` helper functions