### PR TITLE
chore(deps): update uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -38,16 +47,16 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "6.1"
+version = "6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
-    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
 ]
 
 [[package]]
@@ -418,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "model-lib"
-version = "0.102.0"
+version = "0.102.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -427,9 +436,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "zero-3rdparty" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/36/268327325ef234c630f9fdfebe9050036dd420186f0aa7fd30e1b0ca8db0/model_lib-0.102.0.tar.gz", hash = "sha256:944529345e09cc8616993e4ce738d4ad4e57420cd8fc9832256f8911236edbf0", size = 19555, upload-time = "2026-01-24T18:46:57.074Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/e7/273ba9986e02f8f7e24f4587c40eb490503ed83237258e74dba1c9411bd7/model_lib-0.102.1.tar.gz", hash = "sha256:e7842f0234806b050fd09927743078c513d42f00fd892dd5b9bbdedd6e0bcb4f", size = 19591, upload-time = "2026-02-11T07:34:30.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/e8/a9c9395eaa4e38fa156e7fe4fa8f601572f1bc23cc511aa0b27d49e052e7/model_lib-0.102.0-py3-none-any.whl", hash = "sha256:adf303f8b0b0a37b0016be44457b327ea4d5d7f7da2d168d4324ea2be1bfb1de", size = 27368, upload-time = "2026-01-24T18:46:55.914Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/90/9c8a041003d5af750757d5b35faf8760ce618b9daedbc0a0225f6ea81313/model_lib-0.102.1-py3-none-any.whl", hash = "sha256:b991d7eac0f06dd37865294241e9f4b920c618d8f998d03b95b970404074bf57", size = 27371, upload-time = "2026-02-11T07:34:29.65Z" },
 ]
 
 [package.optional-dependencies]
@@ -466,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "path-sync"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
@@ -524,7 +533,7 @@ wheels = [
 
 [[package]]
 name = "pkg-ext"
-version = "0.3.3"
+version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ask-shell" },
@@ -533,18 +542,18 @@ dependencies = [
     { name = "tomlkit" },
     { name = "zero-3rdparty" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/09/6b048a43051b4c4cc6fbdfd398b50327b538721ffff366c2e53461a06322/pkg_ext-0.3.3.tar.gz", hash = "sha256:c63c4590b3eafb682d7997d1d8f907f1fb160898611fd13300f9016bd3a5548a", size = 76328, upload-time = "2026-02-06T10:51:09.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/9c/1ede8503e03f3e1a353764b472e8f191e5b32a33ae2fc9996d892be1c07b/pkg_ext-0.3.5.tar.gz", hash = "sha256:c69a2cb9a3c29c8a6738c5238f7070e041cd051a7bd078c348b22a65c494e798", size = 76524, upload-time = "2026-02-17T21:22:00.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/87/ccf5316b2b05971e39dfc02dec3bbd26bda1c35bf239d5c348359dc612a6/pkg_ext-0.3.3-py3-none-any.whl", hash = "sha256:006609865a8f12f2fedb4a3644b14c70c8458c1347a6e72d5b603905b007c90c", size = 110309, upload-time = "2026-02-06T10:51:08.298Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/ec881bda1020ca2818595a5eff90ec18679687fc5dffc4c4bd77d3d6b24f/pkg_ext-0.3.5-py3-none-any.whl", hash = "sha256:0a72fc4fa656c63320d1054c00d6adc4a75efe663477e6fd522b93e9965c96f1", size = 110512, upload-time = "2026-02-17T21:21:59.588Z" },
 ]
 
 [[package]]
 name = "platformdirs"
-version = "4.5.1"
+version = "4.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
 ]
 
 [[package]]
@@ -638,16 +647,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/a1/ae859ffac5a3338a66b74c5e29e244fd3a3cc483c89feaf9f56c39898d75/pydantic_settings-2.13.0.tar.gz", hash = "sha256:95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe", size = 222450, upload-time = "2026-02-15T12:11:23.476Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1a/dd1b9d7e627486cf8e7523d09b70010e05a4bc41414f4ae6ce184cf0afb6/pydantic_settings-2.13.0-py3-none-any.whl", hash = "sha256:d67b576fff39cd086b595441bf9c75d4193ca9c0ed643b90360694d0f1240246", size = 58429, upload-time = "2026-02-15T12:11:22.133Z" },
 ]
 
 [[package]]
@@ -661,15 +670,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.20.1"
+version = "10.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
 ]
 
 [[package]]
@@ -864,27 +873,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.0"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/dc/4e6ac71b511b141cf626357a3946679abeba4cf67bc7cc5a17920f31e10d/ruff-0.15.1.tar.gz", hash = "sha256:c590fe13fb57c97141ae975c03a1aedb3d3156030cabd740d6ff0b0d601e203f", size = 4540855, upload-time = "2026-02-12T23:09:09.998Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
-    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
-    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bf/e6e4324238c17f9d9120a9d60aa99a7daaa21204c07fcd84e2ef03bb5fd1/ruff-0.15.1-py3-none-linux_armv6l.whl", hash = "sha256:b101ed7cf4615bda6ffe65bdb59f964e9f4a0d3f85cbf0e54f0ab76d7b90228a", size = 10367819, upload-time = "2026-02-12T23:09:03.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ea/c8f89d32e7912269d38c58f3649e453ac32c528f93bb7f4219258be2e7ed/ruff-0.15.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:939c995e9277e63ea632cc8d3fae17aa758526f49a9a850d2e7e758bfef46602", size = 10798618, upload-time = "2026-02-12T23:09:22.928Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0f/1d0d88bc862624247d82c20c10d4c0f6bb2f346559d8af281674cf327f15/ruff-0.15.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d83466455fdefe60b8d9c8df81d3c1bbb2115cede53549d3b522ce2bc703899", size = 10148518, upload-time = "2026-02-12T23:08:58.339Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c8/291c49cefaa4a9248e986256df2ade7add79388fe179e0691be06fae6f37/ruff-0.15.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9457e3c3291024866222b96108ab2d8265b477e5b1534c7ddb1810904858d16", size = 10518811, upload-time = "2026-02-12T23:09:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/f5707440e5ae43ffa5365cac8bbb91e9665f4a883f560893829cf16a606b/ruff-0.15.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:92c92b003e9d4f7fbd33b1867bb15a1b785b1735069108dfc23821ba045b29bc", size = 10196169, upload-time = "2026-02-12T23:09:17.306Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ff/26ddc8c4da04c8fd3ee65a89c9fb99eaa5c30394269d424461467be2271f/ruff-0.15.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fe5c41ab43e3a06778844c586251eb5a510f67125427625f9eb2b9526535779", size = 10990491, upload-time = "2026-02-12T23:09:25.503Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/00/50920cb385b89413f7cdb4bb9bc8fc59c1b0f30028d8bccc294189a54955/ruff-0.15.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66a6dd6df4d80dc382c6484f8ce1bcceb55c32e9f27a8b94c32f6c7331bf14fb", size = 11843280, upload-time = "2026-02-12T23:09:19.88Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6d/2f5cad8380caf5632a15460c323ae326f1e1a2b5b90a6ee7519017a017ca/ruff-0.15.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a4a42cbb8af0bda9bcd7606b064d7c0bc311a88d141d02f78920be6acb5aa83", size = 11274336, upload-time = "2026-02-12T23:09:14.907Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/1d/5f56cae1d6c40b8a318513599b35ea4b075d7dc1cd1d04449578c29d1d75/ruff-0.15.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ab064052c31dddada35079901592dfba2e05f5b1e43af3954aafcbc1096a5b2", size = 11137288, upload-time = "2026-02-12T23:09:07.475Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/20/6f8d7d8f768c93b0382b33b9306b3b999918816da46537d5a61635514635/ruff-0.15.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5631c940fe9fe91f817a4c2ea4e81f47bee3ca4aa646134a24374f3c19ad9454", size = 11070681, upload-time = "2026-02-12T23:08:55.43Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/67/d640ac76069f64cdea59dba02af2e00b1fa30e2103c7f8d049c0cff4cafd/ruff-0.15.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:68138a4ba184b4691ccdc39f7795c66b3c68160c586519e7e8444cf5a53e1b4c", size = 10486401, upload-time = "2026-02-12T23:09:27.927Z" },
+    { url = "https://files.pythonhosted.org/packages/65/3d/e1429f64a3ff89297497916b88c32a5cc88eeca7e9c787072d0e7f1d3e1e/ruff-0.15.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:518f9af03bfc33c03bdb4cb63fabc935341bb7f54af500f92ac309ecfbba6330", size = 10197452, upload-time = "2026-02-12T23:09:12.147Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/e2c3bade17dad63bf1e1c2ffaf11490603b760be149e1419b07049b36ef2/ruff-0.15.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:da79f4d6a826caaea95de0237a67e33b81e6ec2e25fc7e1993a4015dffca7c61", size = 10693900, upload-time = "2026-02-12T23:09:34.418Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/27/fdc0e11a813e6338e0706e8b39bb7a1d61ea5b36873b351acee7e524a72a/ruff-0.15.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3dd86dccb83cd7d4dcfac303ffc277e6048600dfc22e38158afa208e8bf94a1f", size = 11227302, upload-time = "2026-02-12T23:09:36.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
 ]
 
 [[package]]
@@ -934,17 +943,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.21.1"
+version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b6/3e681d3b6bb22647509bdbfdd18055d5adc0dce5c5585359fa46ff805fdc/typer-0.24.0.tar.gz", hash = "sha256:f9373dc4eff901350694f519f783c29b6d7a110fc0dcc11b1d7e353b85ca6504", size = 118380, upload-time = "2026-02-16T22:08:48.496Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d0/4da85c2a45054bb661993c93524138ace4956cb075a7ae0c9d1deadc331b/typer-0.24.0-py3-none-any.whl", hash = "sha256:5fc435a9c8356f6160ed6e85a6301fdd6e3d8b2851da502050d1f92c5e9eddc8", size = 56441, upload-time = "2026-02-16T22:08:47.535Z" },
 ]
 
 [[package]]
@@ -1009,9 +1018,9 @@ wheels = [
 
 [[package]]
 name = "zero-3rdparty"
-version = "0.104.2"
+version = "0.104.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3d/f6/81dfd01e984d206f82d149ff9d626f00b285f18ba795c6b8a7abe89f3a29/zero_3rdparty-0.104.2.tar.gz", hash = "sha256:38ec6da4e2af4b2ee8c26472623a354eddb4259dd0b5b23714d3d557bcd5d9dc", size = 35516, upload-time = "2026-02-10T15:19:22.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/b3/f95b9ad004a47ba1e1ab2260b9f11fe0c3fcf88ef422011e75c8d7f9d381/zero_3rdparty-0.104.3.tar.gz", hash = "sha256:114e8e3c39f5c6fac043c2cf16cd72f97989daeb5dc0505eced90d4cfc7816ef", size = 35545, upload-time = "2026-02-12T18:22:17.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/37/743ba3edad590e8b846aa99fd55afae6c2f41ba8585b11985352f5c5b24d/zero_3rdparty-0.104.2-py3-none-any.whl", hash = "sha256:0c31be1173d305f9183696c4accf6681cef6bec0ade498a408d9a6667ef8893a", size = 44615, upload-time = "2026-02-10T15:19:20.864Z" },
+    { url = "https://files.pythonhosted.org/packages/23/7c/6ac82fbe49f82da9c39cc4d36505940affc949cc1cb511400f69325b1e00/zero_3rdparty-0.104.3-py3-none-any.whl", hash = "sha256:82f7834b6a47dc537aba38a34eb52d61ef548d1c4309043d99dd741ecd31f8c5", size = 44648, upload-time = "2026-02-12T18:22:16.228Z" },
 ]


### PR DESCRIPTION
Automated dependency update.

## Command Output

```
Processing path-sync...
Invalid git repo at /tmp/path-sync-deps/path-sync
Cloning https://github.com/EspenAlbert/path-sync to /tmp/path-sync-deps/path-sync
Fetching origin
Checking out main
Creating fresh branch: deps/uv-lock-update
Running: uv -n lock --upgrade
[uv] Using CPython 3.14.0
[uv] Resolved 66 packages in 2.40s
[uv] Added annotated-doc v0.0.4
[uv] Updated backrefs v6.1 -> v6.2
[uv] Updated model-lib v0.102.0 -> v0.102.1
[uv] Updated path-sync v0.7.5 -> v0.7.6
[uv] Updated pkg-ext v0.3.3 -> v0.3.5
[uv] Updated platformdirs v4.5.1 -> v4.9.2
[uv] Updated pydantic-settings v2.12.0 -> v2.13.0
[uv] Updated pymdown-extensions v10.20.1 -> v10.21
[uv] Updated ruff v0.15.0 -> v0.15.1
[uv] Updated typer v0.21.1 -> v0.24.0
[uv] Updated zero-3rdparty v0.104.2 -> v0.104.3
Committed: chore(deps): update uv.lock
Running: uv sync
[uv] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
[uv] Using CPython 3.14.0
[uv] Creating virtual environment at: .venv
[uv] Resolved 66 packages in 0.97ms
[uv]    Building path-sync @ file:///private/tmp/path-sync-deps/path-sync
[uv] Downloading ruff (9.7MiB)
[uv]       Built path-sync @ file:///private/tmp/path-sync-deps/path-sync
[uv]  Downloaded ruff
[uv] Prepared 4 packages in 1.20s
[uv] Installed 31 packages in 276ms
[uv]  + annotated-doc==0.0.4
[uv]  + annotated-types==0.7.0
[uv]  + click==8.3.1
[uv]  + coverage==7.13.4
[uv]  + gitdb==4.0.12
[uv]  + gitpython==3.1.46
[uv]  + iniconfig==2.3.0
[uv]  + markdown-it-py==4.0.0
[uv]  + mdurl==0.1.2
[uv]  + nodeenv==1.10.0
[uv]  + packaging==26.0
[uv]  + path-sync==0.7.6 (from file:///private/tmp/path-sync-deps/path-sync)
[uv]  + pluggy==1.6.0
[uv]  + pydantic==2.12.5
[uv]  + pydantic-core==2.41.5
[uv]  + pygments==2.19.2
[uv]  + pyright==1.1.408
[uv]  + pytest==9.0.2
[uv]  + pytest-asyncio==1.3.0
[uv]  + pytest-cov==7.0.0
[uv]  + pytest-datadir==1.8.0
[uv]  + pytest-regressions==2.10.0
[uv]  + pyyaml==6.0.3
[uv]  + rich==14.3.2
[uv]  + ruff==0.15.1
[uv]  + shellingham==1.5.4
[uv]  + smmap==5.0.2
[uv]  + typer==0.24.0
[uv]  + typing-extensions==4.15.0
[uv]  + typing-inspection==0.4.2
[uv]  + zero-3rdparty==0.104.3
Running: just fmt
[just] 39 files left unchanged
[just] uv run ruff format .
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
[just] Uninstalled 4 packages in 21ms
[just] Installed 5 packages in 4ms
Running: just test
[just] ============================= test session starts ==============================
[just] platform darwin -- Python 3.14.0, pytest-9.0.2, pluggy-1.6.0 -- /private/tmp/path-sync-deps/path-sync/.venv/bin/python3
[just] cachedir: .pytest_cache
[just] rootdir: /private/tmp/path-sync-deps/path-sync
[just] configfile: pyproject.toml
[just] plugins: regressions-2.10.0, datadir-1.8.0, asyncio-1.3.0, cov-7.0.0
[just] asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
[just] collecting ... collected 111 items
[just] 
[just] path_sync/_internal/auto_merge_test.py::test_enable_auto_merge_calls_gh 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:82   https://github.com/o/r/pull/1: enabled auto-merge (rebase)
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_get_pr_checks_parses_json PASSED
[just] path_sync/_internal/auto_merge_test.py::test_get_pr_state_returns_merged PASSED
[just] path_sync/_internal/auto_merge_test.py::test_handle_auto_merge_no_wait_skips_polling 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:149 
[just] ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:150  Auto-merge
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:151 ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:163   --no-wait: skipping merge polling
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_handle_auto_merge_skips_already_merged 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:149 
[just] ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:150  Auto-merge
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:151 ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:157   repo1: already merged
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:163   --no-wait: skipping merge polling
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_pr_merge_result_failed_and_pending_checks PASSED
[just] path_sync/_internal/auto_merge_test.py::test_log_summary_formats_table 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:182 Repo   PR  State    Failed Checks
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:183 ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:186 repo1    MERGED   
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:186 repo2    OPEN     lint
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_wait_for_merge_timeout 
[just] -------------------------------- live log call ---------------------------------
[just] WARNING  path_sync._internal.auto_merge:auto_merge.py:133 Timeout waiting for myrepo after 0s (https://github.com/o/r/pull/1)
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_wait_for_merge_merged 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:121 repo1: merged (https://github.com/o/r/pull/1)
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_no_changes_skips 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:166 test-repo: No changes, skipping
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_update_fails_returns_skipped 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] WARNING  path_sync._internal.cmd_dep_update:cmd_dep_update.py:162 test-repo: Update failed with exit code 1
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_changes_with_skip_verify_passes 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_verify_runs_when_changes_present 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_run_updates_success_returns_none PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_run_updates_failure_returns_step_failure PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_update_and_validate_keeps_pr_when_config_flag_set 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:166 test-repo: No changes, skipping
[just] PASSED
[just] path_sync/_internal/log_capture_test.py::test_capture_log_captures_logger_output 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync.test:log_capture_test.py:12 first message
[just] INFO     path_sync.test:log_capture_test.py:13 second message
[just] PASSED
[just] path_sync/_internal/log_capture_test.py::test_capture_log_read_after_flush_includes_all 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync.test2:log_capture_test.py:24 before flush
[just] INFO     path_sync.test2:log_capture_test.py:26 after first read
[just] PASSED
[just] path_sync/_internal/models_dep_test.py::test_dep_config_parsing PASSED
[just] path_sync/_internal/models_dep_test.py::test_dep_config_from_yaml PASSED
[just] path_sync/_internal/models_dep_test.py::test_resolve_dep_config_path PASSED
[just] path_sync/_internal/models_dep_test.py::test_load_destinations_with_include_filter PASSED
[just] path_sync/_internal/models_dep_test.py::test_load_destinations_with_exclude_filter PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_no_groups PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_with_groups PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_multiple_groups PASSED
[just] path_sync/_internal/models_test.py::test_validation_rejects_unknown_group PASSED
[just] path_sync/_internal/models_test.py::test_validation_rejects_duplicate_group PASSED
[just] path_sync/_internal/models_test.py::test_parse_sync_metadata_from_default_template PASSED
[just] path_sync/_internal/models_test.py::test_parse_sync_metadata_missing PASSED
[just] path_sync/_internal/models_test.py::test_format_body_includes_metadata PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_newer_skips PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_equal_skips PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_older_proceeds PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_no_body PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_no_metadata PASSED
[just] path_sync/_internal/models_test.py::test_format_body_roundtrip_custom_template PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_work_dir PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_relative PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_no_relative_no_workdir PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_clones_when_missing PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_dry_run_raises_when_missing PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_returns_existing PASSED
[just] path_sync/cmd_copy_test.py::test_sync_single_file 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_sync_single_file0/dest/out.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_skips_opted_out_file 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:505 Skipping /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_sync_skips_opted_out_file0/dest/file.py (header removed - opted out)
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_force_overwrite_adds_header_when_content_matches 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_force_overwrite_adds_head0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_cleanup_orphans 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:567 Deleted orphan: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_cleanup_orphans0/dest/orphan.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_with_sections_replaces_managed 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_sync_with_sections_replac0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_with_sections_skip PASSED
[just] path_sync/cmd_copy_test.py::test_ensure_repo_dry_run_errors_if_missing PASSED
[just] path_sync/cmd_copy_test.py::test_copy_options_defaults PASSED
[just] path_sync/cmd_copy_test.py::test_source_with_header_no_duplicate 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_source_with_header_no_dup0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_replace_no_header 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_file_mode_replace_no_head0/dest/LICENSE
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_replace_skips_unchanged PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_scaffold_creates_new 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_file_mode_scaffold_create0/dest/.gitignore
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_scaffold_skips_existing PASSED
[just] path_sync/cmd_copy_test.py::test_sync_new_file_respects_skip_sections 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_sync_new_file_respects_sk0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_steps_empty_returns_passed PASSED
[just] path_sync/cmd_copy_test.py::test_verify_steps_all_pass 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo hello
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] hello
[just] INFO     path_sync._internal.verify:verify.py:41 Running: true
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_skip_strategy 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_fail_strategy 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_warn_strategy_continues 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo after-warn
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] after-warn
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_with_commit_stages_and_commits 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo format
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] format
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_per_step_on_fail_overrides_verify_level 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrap_synced_files_wraps_content_in_section 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_wrap_synced_files_wraps_c0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrap_per_path_override_disables 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_wrap_per_path_override_di0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrapped_file_preserves_dest_content_around_section 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_wrapped_file_preserves_de0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_with_existing_sections_not_double_wrapped 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_file_with_existing_sectio0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_preserves_dest_trailing_when_adding_new_sections 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-1396/test_sync_preserves_dest_trail0/dest/justfile
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_skipped_when_keep_pr_on_no_changes PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_skipped_when_skip_commit PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_runs_by_default PASSED
[just] path_sync/cmd_copy_test.py::test_skip_already_synced_bypassed_when_force_resync PASSED
[just] path_sync/cmd_copy_test.py::test_skip_already_synced_checks_by_default 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:241 dest: open PR already synced from abc12345 (2099-01-01T00:00:00+00:00 >= 2026-01-01T00:00:00), skipping
[just] PASSED
[just] path_sync/header_test.py::test_header_generation PASSED
[just] path_sync/header_test.py::test_has_header_matches_any_config_name PASSED
[just] path_sync/header_test.py::test_add_remove_header PASSED
[just] path_sync/header_test.py::test_add_header_extensionless PASSED
[just] path_sync/header_test.py::test_file_has_header PASSED
[just] path_sync/models_test.py::test_path_mapping_resolved PASSED
[just] path_sync/models_test.py::test_resolve_config_path PASSED
[just] path_sync/models_test.py::test_find_repo_root PASSED
[just] path_sync/models_test.py::test_src_config_find_destination PASSED
[just] path_sync/models_test.py::test_destination_skip_sections PASSED
[just] path_sync/models_test.py::test_destination_skip_file_patterns PASSED
[just] path_sync/models_test.py::test_pr_defaults_format_body PASSED
[just] path_sync/models_test.py::test_pr_defaults_format_body_extracts_repo_name PASSED
[just] path_sync/models_test.py::test_path_mapping_is_excluded PASSED
[just] path_sync/models_test.py::test_destination_resolve_verify PASSED
[just] path_sync/sections_test.py::test_parse_sections PASSED
[just] path_sync/sections_test.py::test_parse_sections_no_markers PASSED
[just] path_sync/sections_test.py::test_parse_sections_nested_error PASSED
[just] path_sync/sections_test.py::test_parse_sections_unclosed_error PASSED
[just] path_sync/sections_test.py::test_parse_sections_standalone_ok_edit PASSED
[just] path_sync/sections_test.py::test_has_sections PASSED
[just] path_sync/sections_test.py::test_wrap_in_default_section PASSED
[just] path_sync/sections_test.py::test_parse_sections_content PASSED
[just] path_sync/sections_test.py::test_replace_sections_updates_content PASSED
[just] path_sync/sections_test.py::test_replace_sections_preserves_ok_edit PASSED
[just] path_sync/sections_test.py::test_replace_sections_skip PASSED
[just] path_sync/sections_test.py::test_replace_sections_adds_new PASSED
[just] path_sync/sections_test.py::test_replace_sections_keeps_dest_only PASSED
[just] path_sync/sections_test.py::test_markdown_sections PASSED
[just] path_sync/sections_test.py::test_parse_resumable_section PASSED
[just] path_sync/sections_test.py::test_replace_resumable_section_preserves_user_content PASSED
[just] path_sync/validation_test.py::test_modify_ok_edit_passes PASSED
[just] path_sync/validation_test.py::test_modify_do_not_edit_fails PASSED
[just] path_sync/validation_test.py::test_skip_section_passes PASSED
[just] path_sync/validation_test.py::test_section_removed_warns_not_fails 
[just] -------------------------------- live log call ---------------------------------
[just] WARNING  path_sync._internal.validation:validation.py:61 Section 'standard' removed from test.py, consider updating src.yaml
[just] PASSED
[just] path_sync/validation_test.py::test_no_sections_full_file_comparison PASSED
[just] path_sync/validation_test.py::test_parse_skip_sections PASSED
[just] 
[just] ============================= 111 passed in 1.88s ==============================
[just] uv run pytest
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Running: just pkg-pre-change --full
[just] uv run --group release pkg-ext pre-change --full
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
[just] Uninstalled 4 packages in 43ms
[just] Installed 4 packages in 5ms
[just] Traceback (most recent call last):
[just]   File "/Users/espen.albert/.local/share/uv/python/cpython-3.14.0-macos-aarch64-none/bin/pkg-ext", line 4, in <module>
[just]     from pkg_ext.cli import main
[just] ModuleNotFoundError: No module named 'pkg_ext'
[just] error: Recipe `pkg-pre-change` failed on line 56 with exit code 1
```

---
## Verification Issues

- `just pkg-pre-change --full` failed (exit code 1, strategy: warn)