### PR TITLE
chore(deps): update uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "ask-shell"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "model-lib", extra = ["toml"] },
@@ -31,9 +31,9 @@ dependencies = [
     { name = "typer" },
     { name = "zero-3rdparty" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/8f/97be0d3634234938998945dae1be78a575ed260ffdc6ddc88fd6dec94b05/ask_shell-0.3.1.tar.gz", hash = "sha256:932f915e26d299b4c6571405f515b83ef9312c392c86cf93df30567c128fd108", size = 29811, upload-time = "2026-01-24T21:50:34.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/ac/f760fb4054ef72ca4f5f46ec6128e1997d69e5375353cf8d1a8d1238d215/ask_shell-0.4.0.tar.gz", hash = "sha256:1e1b58cbb61016f156d08baece71b8161f8ec7cf96171dcc816f7cbbda57eb97", size = 30525, upload-time = "2026-02-25T07:15:45.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/6f/da0266b3756cc622f2027ea6b51a908e407cd7bb5261ba0128c7691b641d/ask_shell-0.3.1-py3-none-any.whl", hash = "sha256:badf78bac627c87621eecffca7ba7dad555f0899ef7332d417f506c723f1a9e0", size = 36887, upload-time = "2026-01-24T21:50:33.059Z" },
+    { url = "https://files.pythonhosted.org/packages/63/fb/506c327cd330bbb67bfcc96654b9a9f8d431c3ba5ac43984ec5a38d452f6/ask_shell-0.4.0-py3-none-any.whl", hash = "sha256:e3a057690f5c64b87591b168fe45c78cdc821e01e17503a6a3086d4e8980424b", size = 37696, upload-time = "2026-02-25T07:15:44.714Z" },
 ]
 
 [[package]]
@@ -61,11 +61,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.1.4"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.1"
+version = "9.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -411,9 +411,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/e2/2ffc356cd72f1473d07c7719d82a8f2cbd261666828614ecb95b12169f41/mkdocs_material-9.7.1.tar.gz", hash = "sha256:89601b8f2c3e6c6ee0a918cc3566cb201d40bf37c3cd3c2067e26fadb8cce2b8", size = 4094392, upload-time = "2025-12-18T09:49:00.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b4/f900fcb8e6f510241e334ca401eddcb61ed880fb6572f7f32e4228472ca1/mkdocs_material-9.7.3.tar.gz", hash = "sha256:e5f0a18319699da7e78c35e4a8df7e93537a888660f61a86bd773a7134798f22", size = 4097748, upload-time = "2026-02-24T12:06:22.646Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl", hash = "sha256:3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c", size = 9297166, upload-time = "2025-12-18T09:48:56.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/1b/16ad0193079bb8a15aa1d2620813a9cd15b18de150a4ea1b2c607fb4c74d/mkdocs_material-9.7.3-py3-none-any.whl", hash = "sha256:37ebf7b4788c992203faf2e71900be3c197c70a4be9b0d72aed537b08a91dd9d", size = 9305078, upload-time = "2026-02-24T12:06:19.155Z" },
 ]
 
 [[package]]
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "model-lib"
-version = "0.102.1"
+version = "0.102.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -436,9 +436,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "zero-3rdparty" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/e7/273ba9986e02f8f7e24f4587c40eb490503ed83237258e74dba1c9411bd7/model_lib-0.102.1.tar.gz", hash = "sha256:e7842f0234806b050fd09927743078c513d42f00fd892dd5b9bbdedd6e0bcb4f", size = 19591, upload-time = "2026-02-11T07:34:30.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/85/a3e6ce436813f153cfd730e374d55eb010e4466eb78cdc88fd0de0702811/model_lib-0.102.2.tar.gz", hash = "sha256:d712557be23a3d06d88630b968f946601848d2a6e41756ae0377f02311c5f599", size = 19596, upload-time = "2026-02-18T06:44:29.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/90/9c8a041003d5af750757d5b35faf8760ce618b9daedbc0a0225f6ea81313/model_lib-0.102.1-py3-none-any.whl", hash = "sha256:b991d7eac0f06dd37865294241e9f4b920c618d8f998d03b95b970404074bf57", size = 27371, upload-time = "2026-02-11T07:34:29.65Z" },
+    { url = "https://files.pythonhosted.org/packages/49/cf/75d537cfc77514b7405f3462b7256a183e9ab1fdda9358d1863864151f17/model_lib-0.102.2-py3-none-any.whl", hash = "sha256:448f346237cbe1eb4a220f715907f20fb859e7c8f0774f1daee0b74f5cea4352", size = 27365, upload-time = "2026-02-18T06:44:28.421Z" },
 ]
 
 [package.optional-dependencies]
@@ -493,6 +493,18 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-regressions" },
     { name = "ruff" },
+    { name = "vulture" },
+]
+dev-lint = [
+    { name = "pyright" },
+    { name = "ruff" },
+    { name = "vulture" },
+]
+dev-test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-regressions" },
 ]
 docs = [
     { name = "mkdocs-material" },
@@ -518,6 +530,18 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-regressions", specifier = ">=2.6" },
     { name = "ruff", specifier = ">=0.14" },
+    { name = "vulture", specifier = ">=2.14" },
+]
+dev-lint = [
+    { name = "pyright", specifier = ">=1.1" },
+    { name = "ruff", specifier = ">=0.14" },
+    { name = "vulture", specifier = ">=2.14" },
+]
+dev-test = [
+    { name = "pytest", specifier = ">=9.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=7.0" },
+    { name = "pytest-regressions", specifier = ">=2.6" },
 ]
 docs = [{ name = "mkdocs-material", specifier = ">=9.5" }]
 release = [{ name = "pkg-ext" }]
@@ -533,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "pkg-ext"
-version = "0.3.5"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ask-shell" },
@@ -542,9 +566,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "zero-3rdparty" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/9c/1ede8503e03f3e1a353764b472e8f191e5b32a33ae2fc9996d892be1c07b/pkg_ext-0.3.5.tar.gz", hash = "sha256:c69a2cb9a3c29c8a6738c5238f7070e041cd051a7bd078c348b22a65c494e798", size = 76524, upload-time = "2026-02-17T21:22:00.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/b4/2e413ae7e0fa7e289dc70a454641cc93006f3bce714139aac9ce49ae4cb8/pkg_ext-0.4.0.tar.gz", hash = "sha256:ff91f82573a3ae7cd6f107a7064a3cc5e51cbd798b9a21d9fce0f41611d01ff7", size = 77571, upload-time = "2026-02-24T23:40:00.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/3c/ec881bda1020ca2818595a5eff90ec18679687fc5dffc4c4bd77d3d6b24f/pkg_ext-0.3.5-py3-none-any.whl", hash = "sha256:0a72fc4fa656c63320d1054c00d6adc4a75efe663477e6fd522b93e9965c96f1", size = 110512, upload-time = "2026-02-17T21:21:59.588Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/49/dc1e42b27cb386fc355eacf24ce5bce4212306cdf4836c9453ced4367731/pkg_ext-0.4.0-py3-none-any.whl", hash = "sha256:89065e52e243a86e4bc7dbcce8b217ceec165f6bcba11b90ccec343a7c38da95", size = 112099, upload-time = "2026-02-24T23:39:58.956Z" },
 ]
 
 [[package]]
@@ -647,16 +671,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.0"
+version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/a1/ae859ffac5a3338a66b74c5e29e244fd3a3cc483c89feaf9f56c39898d75/pydantic_settings-2.13.0.tar.gz", hash = "sha256:95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe", size = 222450, upload-time = "2026-02-15T12:11:23.476Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/1a/dd1b9d7e627486cf8e7523d09b70010e05a4bc41414f4ae6ce184cf0afb6/pydantic_settings-2.13.0-py3-none-any.whl", hash = "sha256:d67b576fff39cd086b595441bf9c75d4193ca9c0ed643b90360694d0f1240246", size = 58429, upload-time = "2026-02-15T12:11:22.133Z" },
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
 ]
 
 [[package]]
@@ -860,40 +884,40 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.2"
+version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]
 name = "ruff"
-version = "0.15.1"
+version = "0.15.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/dc/4e6ac71b511b141cf626357a3946679abeba4cf67bc7cc5a17920f31e10d/ruff-0.15.1.tar.gz", hash = "sha256:c590fe13fb57c97141ae975c03a1aedb3d3156030cabd740d6ff0b0d601e203f", size = 4540855, upload-time = "2026-02-12T23:09:09.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148, upload-time = "2026-02-19T22:32:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/bf/e6e4324238c17f9d9120a9d60aa99a7daaa21204c07fcd84e2ef03bb5fd1/ruff-0.15.1-py3-none-linux_armv6l.whl", hash = "sha256:b101ed7cf4615bda6ffe65bdb59f964e9f4a0d3f85cbf0e54f0ab76d7b90228a", size = 10367819, upload-time = "2026-02-12T23:09:03.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ea/c8f89d32e7912269d38c58f3649e453ac32c528f93bb7f4219258be2e7ed/ruff-0.15.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:939c995e9277e63ea632cc8d3fae17aa758526f49a9a850d2e7e758bfef46602", size = 10798618, upload-time = "2026-02-12T23:09:22.928Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/0f/1d0d88bc862624247d82c20c10d4c0f6bb2f346559d8af281674cf327f15/ruff-0.15.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d83466455fdefe60b8d9c8df81d3c1bbb2115cede53549d3b522ce2bc703899", size = 10148518, upload-time = "2026-02-12T23:08:58.339Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/c8/291c49cefaa4a9248e986256df2ade7add79388fe179e0691be06fae6f37/ruff-0.15.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9457e3c3291024866222b96108ab2d8265b477e5b1534c7ddb1810904858d16", size = 10518811, upload-time = "2026-02-12T23:09:31.865Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/1a/f5707440e5ae43ffa5365cac8bbb91e9665f4a883f560893829cf16a606b/ruff-0.15.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:92c92b003e9d4f7fbd33b1867bb15a1b785b1735069108dfc23821ba045b29bc", size = 10196169, upload-time = "2026-02-12T23:09:17.306Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/ff/26ddc8c4da04c8fd3ee65a89c9fb99eaa5c30394269d424461467be2271f/ruff-0.15.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fe5c41ab43e3a06778844c586251eb5a510f67125427625f9eb2b9526535779", size = 10990491, upload-time = "2026-02-12T23:09:25.503Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/00/50920cb385b89413f7cdb4bb9bc8fc59c1b0f30028d8bccc294189a54955/ruff-0.15.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66a6dd6df4d80dc382c6484f8ce1bcceb55c32e9f27a8b94c32f6c7331bf14fb", size = 11843280, upload-time = "2026-02-12T23:09:19.88Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/6d/2f5cad8380caf5632a15460c323ae326f1e1a2b5b90a6ee7519017a017ca/ruff-0.15.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a4a42cbb8af0bda9bcd7606b064d7c0bc311a88d141d02f78920be6acb5aa83", size = 11274336, upload-time = "2026-02-12T23:09:14.907Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/1d/5f56cae1d6c40b8a318513599b35ea4b075d7dc1cd1d04449578c29d1d75/ruff-0.15.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ab064052c31dddada35079901592dfba2e05f5b1e43af3954aafcbc1096a5b2", size = 11137288, upload-time = "2026-02-12T23:09:07.475Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/20/6f8d7d8f768c93b0382b33b9306b3b999918816da46537d5a61635514635/ruff-0.15.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5631c940fe9fe91f817a4c2ea4e81f47bee3ca4aa646134a24374f3c19ad9454", size = 11070681, upload-time = "2026-02-12T23:08:55.43Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/67/d640ac76069f64cdea59dba02af2e00b1fa30e2103c7f8d049c0cff4cafd/ruff-0.15.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:68138a4ba184b4691ccdc39f7795c66b3c68160c586519e7e8444cf5a53e1b4c", size = 10486401, upload-time = "2026-02-12T23:09:27.927Z" },
-    { url = "https://files.pythonhosted.org/packages/65/3d/e1429f64a3ff89297497916b88c32a5cc88eeca7e9c787072d0e7f1d3e1e/ruff-0.15.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:518f9af03bfc33c03bdb4cb63fabc935341bb7f54af500f92ac309ecfbba6330", size = 10197452, upload-time = "2026-02-12T23:09:12.147Z" },
-    { url = "https://files.pythonhosted.org/packages/78/83/e2c3bade17dad63bf1e1c2ffaf11490603b760be149e1419b07049b36ef2/ruff-0.15.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:da79f4d6a826caaea95de0237a67e33b81e6ec2e25fc7e1993a4015dffca7c61", size = 10693900, upload-time = "2026-02-12T23:09:34.418Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/27/fdc0e11a813e6338e0706e8b39bb7a1d61ea5b36873b351acee7e524a72a/ruff-0.15.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3dd86dccb83cd7d4dcfac303ffc277e6048600dfc22e38158afa208e8bf94a1f", size = 11227302, upload-time = "2026-02-12T23:09:36.536Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565, upload-time = "2026-02-19T22:32:41.824Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354, upload-time = "2026-02-19T22:32:07.366Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767, upload-time = "2026-02-19T22:32:13.188Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591, upload-time = "2026-02-19T22:32:02.547Z" },
+    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771, upload-time = "2026-02-19T22:32:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791, upload-time = "2026-02-19T22:32:31.642Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271, upload-time = "2026-02-19T22:32:29.305Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707, upload-time = "2026-02-19T22:32:22.492Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151, upload-time = "2026-02-19T22:32:44.234Z" },
+    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132, upload-time = "2026-02-19T22:32:24.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717, upload-time = "2026-02-19T22:32:26.75Z" },
+    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122, upload-time = "2026-02-19T22:32:10.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295, upload-time = "2026-02-19T22:32:39.227Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641, upload-time = "2026-02-19T22:32:34.617Z" },
+    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
 ]
 
 [[package]]
@@ -943,7 +967,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.24.0"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -951,9 +975,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/b6/3e681d3b6bb22647509bdbfdd18055d5adc0dce5c5585359fa46ff805fdc/typer-0.24.0.tar.gz", hash = "sha256:f9373dc4eff901350694f519f783c29b6d7a110fc0dcc11b1d7e353b85ca6504", size = 118380, upload-time = "2026-02-16T22:08:48.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/d0/4da85c2a45054bb661993c93524138ace4956cb075a7ae0c9d1deadc331b/typer-0.24.0-py3-none-any.whl", hash = "sha256:5fc435a9c8356f6160ed6e85a6301fdd6e3d8b2851da502050d1f92c5e9eddc8", size = 56441, upload-time = "2026-02-16T22:08:47.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]
@@ -984,6 +1008,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/25/925f35db758a0f9199113aaf61d703de891676b082bd7cf73ea01d6000f7/vulture-2.14.tar.gz", hash = "sha256:cb8277902a1138deeab796ec5bef7076a6e0248ca3607a3f3dee0b6d9e9b8415", size = 58823, upload-time = "2024-12-08T17:39:43.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/56/0cc15b8ff2613c1d5c3dc1f3f576ede1c43868c1bc2e5ccaa2d4bcd7974d/vulture-2.14-py2.py3-none-any.whl", hash = "sha256:d9a90dba89607489548a49d557f8bac8112bd25d3cbc8aeef23e860811bd5ed9", size = 28915, upload-time = "2024-12-08T17:39:40.573Z" },
 ]
 
 [[package]]
@@ -1018,9 +1051,9 @@ wheels = [
 
 [[package]]
 name = "zero-3rdparty"
-version = "0.104.3"
+version = "0.104.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d2/b3/f95b9ad004a47ba1e1ab2260b9f11fe0c3fcf88ef422011e75c8d7f9d381/zero_3rdparty-0.104.3.tar.gz", hash = "sha256:114e8e3c39f5c6fac043c2cf16cd72f97989daeb5dc0505eced90d4cfc7816ef", size = 35545, upload-time = "2026-02-12T18:22:17.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/0407bcd7dd4e081eecfe7ac0dfa9d5cfc33bd5baf781f86ea8d213c0f81a/zero_3rdparty-0.104.4.tar.gz", hash = "sha256:5c6c9219ffb03aced9378d7f40f63cc9e193c7b15e3fa21956bc3eb6e37cde40", size = 35505, upload-time = "2026-02-18T06:40:48.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/7c/6ac82fbe49f82da9c39cc4d36505940affc949cc1cb511400f69325b1e00/zero_3rdparty-0.104.3-py3-none-any.whl", hash = "sha256:82f7834b6a47dc537aba38a34eb52d61ef548d1c4309043d99dd741ecd31f8c5", size = 44648, upload-time = "2026-02-12T18:22:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ba/1b7732d573c98f1834af29f6455fe14a3df9a638d2c7fd0a152cc65762e1/zero_3rdparty-0.104.4-py3-none-any.whl", hash = "sha256:ab115bfee2d7bbd201a526980e1c887419819789f3b11dc393af26ba09f17f0f", size = 44616, upload-time = "2026-02-18T06:40:47.381Z" },
 ]


### PR DESCRIPTION
Automated dependency update.

## Command Output

```
Processing path-sync...
Fetching origin
Checking out main
Deleted existing local branch: deps/uv-lock-update
Creating fresh branch: deps/uv-lock-update
Running: uv -n lock --upgrade
[uv] Resolved 67 packages in 1.88s
[uv] Updated ask-shell v0.3.1 -> v0.4.0
[uv] Updated certifi v2026.1.4 -> v2026.2.25
[uv] Updated mkdocs-material v9.7.1 -> v9.7.3
[uv] Updated model-lib v0.102.1 -> v0.102.2
[uv] Updated pkg-ext v0.3.5 -> v0.4.0
[uv] Updated pydantic-settings v2.13.0 -> v2.13.1
[uv] Updated rich v14.3.2 -> v14.3.3
[uv] Updated ruff v0.15.1 -> v0.15.2
[uv] Updated typer v0.24.0 -> v0.24.1
[uv] Added vulture v2.14
[uv] Updated zero-3rdparty v0.104.3 -> v0.104.4
Committed: chore(deps): update uv.lock
Running: uv sync
[uv] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
[uv] Resolved 67 packages in 5ms
[uv]    Building path-sync @ file:///private/tmp/path-sync-deps/path-sync
[uv]       Built path-sync @ file:///private/tmp/path-sync-deps/path-sync
[uv] Prepared 1 package in 316ms
[uv] Uninstalled 12 packages in 93ms
[uv] Installed 1 package in 3ms
[uv]  - ask-shell==0.3.2
[uv]  - model-lib==0.102.2
[uv]  ~ path-sync==0.7.6 (from file:///private/tmp/path-sync-deps/path-sync)
[uv]  - pkg-ext==0.4.0
[uv]  - platformdirs==4.9.2
[uv]  - prompt-toolkit==3.0.52
[uv]  - pydantic-settings==2.13.1
[uv]  - python-dotenv==1.2.1
[uv]  - questionary==2.1.1
[uv]  - tomli-w==1.1.0
[uv]  - tomlkit==0.14.0
[uv]  - wcwidth==0.6.0
Running: just fmt
[just] 39 files left unchanged
[just] uv run ruff format .
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Running: just test
[just] ============================= test session starts ==============================
[just] platform darwin -- Python 3.14.0, pytest-9.0.2, pluggy-1.6.0 -- /private/tmp/path-sync-deps/path-sync/.venv/bin/python
[just] cachedir: .pytest_cache
[just] rootdir: /private/tmp/path-sync-deps/path-sync
[just] configfile: pyproject.toml
[just] plugins: regressions-2.10.0, datadir-1.8.0, asyncio-1.3.0, cov-7.0.0
[just] asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
[just] collecting ... collected 111 items
[just] 
[just] path_sync/_internal/auto_merge_test.py::test_enable_auto_merge_calls_gh 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:84   https://github.com/o/r/pull/1: enabled auto-merge (rebase)
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_get_pr_checks_parses_json PASSED
[just] path_sync/_internal/auto_merge_test.py::test_get_pr_state_returns_merged PASSED
[just] path_sync/_internal/auto_merge_test.py::test_handle_auto_merge_no_wait_skips_polling 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:151 
[just] ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:152  Auto-merge
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:153 ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:165   --no-wait: skipping merge polling
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_handle_auto_merge_skips_already_merged 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:151 
[just] ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:152  Auto-merge
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:153 ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:159   repo1: already merged
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:165   --no-wait: skipping merge polling
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_pr_merge_result_failed_and_pending_checks PASSED
[just] path_sync/_internal/auto_merge_test.py::test_log_summary_formats_table 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:184 Repo   PR  State    Failed Checks
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:185 ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:188 repo1    MERGED   
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:188 repo2    OPEN     lint
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_wait_for_merge_timeout 
[just] -------------------------------- live log call ---------------------------------
[just] WARNING  path_sync._internal.auto_merge:auto_merge.py:135 Timeout waiting for myrepo after 0s (https://github.com/o/r/pull/1)
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_wait_for_merge_merged 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:123 repo1: merged (https://github.com/o/r/pull/1)
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_no_changes_skips 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:166 test-repo: No changes, skipping
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_update_fails_returns_skipped 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] WARNING  path_sync._internal.cmd_dep_update:cmd_dep_update.py:162 test-repo: Update failed with exit code 1
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_changes_with_skip_verify_passes 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_verify_runs_when_changes_present 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_run_updates_success_returns_none PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_run_updates_failure_returns_step_failure PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_update_and_validate_keeps_pr_when_config_flag_set 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:166 test-repo: No changes, skipping
[just] PASSED
[just] path_sync/_internal/log_capture_test.py::test_capture_log_captures_logger_output 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync.test:log_capture_test.py:12 first message
[just] INFO     path_sync.test:log_capture_test.py:13 second message
[just] PASSED
[just] path_sync/_internal/log_capture_test.py::test_capture_log_read_after_flush_includes_all 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync.test2:log_capture_test.py:24 before flush
[just] INFO     path_sync.test2:log_capture_test.py:26 after first read
[just] PASSED
[just] path_sync/_internal/models_dep_test.py::test_dep_config_parsing PASSED
[just] path_sync/_internal/models_dep_test.py::test_dep_config_from_yaml PASSED
[just] path_sync/_internal/models_dep_test.py::test_resolve_dep_config_path PASSED
[just] path_sync/_internal/models_dep_test.py::test_load_destinations_with_include_filter PASSED
[just] path_sync/_internal/models_dep_test.py::test_load_destinations_with_exclude_filter PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_no_groups PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_with_groups PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_multiple_groups PASSED
[just] path_sync/_internal/models_test.py::test_validation_rejects_unknown_group PASSED
[just] path_sync/_internal/models_test.py::test_validation_rejects_duplicate_group PASSED
[just] path_sync/_internal/models_test.py::test_parse_sync_metadata_from_default_template PASSED
[just] path_sync/_internal/models_test.py::test_parse_sync_metadata_missing PASSED
[just] path_sync/_internal/models_test.py::test_format_body_includes_metadata PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_newer_skips PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_equal_skips PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_older_proceeds PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_no_body PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_no_metadata PASSED
[just] path_sync/_internal/models_test.py::test_format_body_roundtrip_custom_template PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_work_dir PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_relative PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_no_relative_no_workdir PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_clones_when_missing PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_dry_run_raises_when_missing PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_returns_existing PASSED
[just] path_sync/cmd_copy_test.py::test_sync_single_file 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_sync_single_file0/dest/out.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_skips_opted_out_file 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:505 Skipping /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_sync_skips_opted_out_file0/dest/file.py (header removed - opted out)
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_force_overwrite_adds_header_when_content_matches 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_force_overwrite_adds_head0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_cleanup_orphans 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:567 Deleted orphan: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_cleanup_orphans0/dest/orphan.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_with_sections_replaces_managed 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_sync_with_sections_replac0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_with_sections_skip PASSED
[just] path_sync/cmd_copy_test.py::test_ensure_repo_dry_run_errors_if_missing PASSED
[just] path_sync/cmd_copy_test.py::test_copy_options_defaults PASSED
[just] path_sync/cmd_copy_test.py::test_source_with_header_no_duplicate 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_source_with_header_no_dup0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_replace_no_header 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_file_mode_replace_no_head0/dest/LICENSE
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_replace_skips_unchanged PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_scaffold_creates_new 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_file_mode_scaffold_create0/dest/.gitignore
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_scaffold_skips_existing PASSED
[just] path_sync/cmd_copy_test.py::test_sync_new_file_respects_skip_sections 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_sync_new_file_respects_sk0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_steps_empty_returns_passed PASSED
[just] path_sync/cmd_copy_test.py::test_verify_steps_all_pass 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo hello
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] hello
[just] INFO     path_sync._internal.verify:verify.py:41 Running: true
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_skip_strategy 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_fail_strategy 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_warn_strategy_continues 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo after-warn
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] after-warn
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_with_commit_stages_and_commits 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo format
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] format
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_per_step_on_fail_overrides_verify_level 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrap_synced_files_wraps_content_in_section 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_wrap_synced_files_wraps_c0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrap_per_path_override_disables 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_wrap_per_path_override_di0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrapped_file_preserves_dest_content_around_section 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_wrapped_file_preserves_de0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_with_existing_sections_not_double_wrapped 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_file_with_existing_sectio0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_preserves_dest_trailing_when_adding_new_sections 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-73/test_sync_preserves_dest_trail0/dest/justfile
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_skipped_when_keep_pr_on_no_changes PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_skipped_when_skip_commit PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_runs_by_default PASSED
[just] path_sync/cmd_copy_test.py::test_skip_already_synced_bypassed_when_force_resync PASSED
[just] path_sync/cmd_copy_test.py::test_skip_already_synced_checks_by_default 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:241 dest: open PR already synced from abc12345 (2099-01-01T00:00:00+00:00 >= 2026-01-01T00:00:00), skipping
[just] PASSED
[just] path_sync/header_test.py::test_header_generation PASSED
[just] path_sync/header_test.py::test_has_header_matches_any_config_name PASSED
[just] path_sync/header_test.py::test_add_remove_header PASSED
[just] path_sync/header_test.py::test_add_header_extensionless PASSED
[just] path_sync/header_test.py::test_file_has_header PASSED
[just] path_sync/models_test.py::test_path_mapping_resolved PASSED
[just] path_sync/models_test.py::test_resolve_config_path PASSED
[just] path_sync/models_test.py::test_find_repo_root PASSED
[just] path_sync/models_test.py::test_src_config_find_destination PASSED
[just] path_sync/models_test.py::test_destination_skip_sections PASSED
[just] path_sync/models_test.py::test_destination_skip_file_patterns PASSED
[just] path_sync/models_test.py::test_pr_defaults_format_body PASSED
[just] path_sync/models_test.py::test_pr_defaults_format_body_extracts_repo_name PASSED
[just] path_sync/models_test.py::test_path_mapping_is_excluded PASSED
[just] path_sync/models_test.py::test_destination_resolve_verify PASSED
[just] path_sync/sections_test.py::test_parse_sections PASSED
[just] path_sync/sections_test.py::test_parse_sections_no_markers PASSED
[just] path_sync/sections_test.py::test_parse_sections_nested_error PASSED
[just] path_sync/sections_test.py::test_parse_sections_unclosed_error PASSED
[just] path_sync/sections_test.py::test_parse_sections_standalone_ok_edit PASSED
[just] path_sync/sections_test.py::test_has_sections PASSED
[just] path_sync/sections_test.py::test_wrap_in_default_section PASSED
[just] path_sync/sections_test.py::test_parse_sections_content PASSED
[just] path_sync/sections_test.py::test_replace_sections_updates_content PASSED
[just] path_sync/sections_test.py::test_replace_sections_preserves_ok_edit PASSED
[just] path_sync/sections_test.py::test_replace_sections_skip PASSED
[just] path_sync/sections_test.py::test_replace_sections_adds_new PASSED
[just] path_sync/sections_test.py::test_replace_sections_keeps_dest_only PASSED
[just] path_sync/sections_test.py::test_markdown_sections PASSED
[just] path_sync/sections_test.py::test_parse_resumable_section PASSED
[just] path_sync/sections_test.py::test_replace_resumable_section_preserves_user_content PASSED
[just] path_sync/validation_test.py::test_modify_ok_edit_passes PASSED
[just] path_sync/validation_test.py::test_modify_do_not_edit_fails PASSED
[just] path_sync/validation_test.py::test_skip_section_passes PASSED
[just] path_sync/validation_test.py::test_section_removed_warns_not_fails 
[just] -------------------------------- live log call ---------------------------------
[just] WARNING  path_sync._internal.validation:validation.py:61 Section 'standard' removed from test.py, consider updating src.yaml
[just] PASSED
[just] path_sync/validation_test.py::test_no_sections_full_file_comparison PASSED
[just] path_sync/validation_test.py::test_parse_skip_sections PASSED
[just] 
[just] ============================= 111 passed in 1.31s ==============================
[just] uv run pytest
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Running: just pkg-pre-change --full
[just] [07:31:06] INFO     ✅ '/opt/homebrew/bin/gh api user --jq .login' completed in 0.55s                                                                      rich_progress.py:51
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyStep -> _internal.models.VerifyStep (group: dep_update)                                             groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.CommitConfig -> _internal.models.CommitConfig (group: dep_update)                                         groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.OnFailStrategy -> _internal.models.OnFailStrategy (group: dep_update)                                     groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyConfig -> _internal.models.VerifyConfig (group: dep_update)                                         groups.py:166
[just] [07:31:07] INFO     ✅ '/opt/homebrew/bin/gh pr view --json baseRefName,url,baseRefOid' completed in 1.02s                                                 rich_progress.py:51
[just]            INFO     No removed references found in the package                                                                                                   removed.py:48
[just]            INFO     ✅ New References expose/hide decisions completed in 0.00s                                                                             rich_progress.py:51
[just]            WARNING  no changelog file @ /private/tmp/path-sync-deps/path-sync/.changelog/029.yaml                                                               actions.py:362
[just]            WARNING  no changelog file @ /private/tmp/path-sync-deps/path-sync/.changelog/029.yaml                                                               actions.py:362
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyStep -> _internal.models.VerifyStep (group: dep_update)                                             groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.CommitConfig -> _internal.models.CommitConfig (group: dep_update)                                         groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.OnFailStrategy -> _internal.models.OnFailStrategy (group: dep_update)                                     groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyConfig -> _internal.models.VerifyConfig (group: dep_update)                                         groups.py:166
[just]            INFO     API dump written to /private/tmp/path-sync-deps/path-sync/path_sync.api-dev.yaml                                                          workflows.py:249
[just]            INFO     No API changes detected                                                                                                                   workflows.py:269
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyStep -> _internal.models.VerifyStep (group: dep_update)                                             groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.CommitConfig -> _internal.models.CommitConfig (group: dep_update)                                         groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.OnFailStrategy -> _internal.models.OnFailStrategy (group: dep_update)                                     groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyConfig -> _internal.models.VerifyConfig (group: dep_update)                                         groups.py:166
[just]            INFO     Regenerated 18 doc files                                                                                                              workflow_cmds.py:200
[just] [07:31:07] You can find the run logs in /Users/espen.albert/code/z_cache/ask_shell/pkg-ext/pre_change/2026-02-25T07-31-05Z                                 typer_command.py:26
[just]            INFO     ✅ Running: '/private/tmp/path-sync-deps/path-sync/.venv/bin/pkg-ext pre-change --full' completed in 2.22s                             rich_progress.py:51
[just] uv run --group release pkg-ext pre-change --full
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
[just] Installed 11 packages in 10ms
[just] /private/tmp/path-sync-deps/path-sync/.venv/lib/python3.14/site-packages/model_lib/pydantic_utils.py:7: UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
[just]   from pydantic.v1.datetime_parse import parse_datetime
```