### PR TITLE
chore(deps): update uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -557,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "pkg-ext"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ask-shell" },
@@ -566,9 +566,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "zero-3rdparty" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/b4/2e413ae7e0fa7e289dc70a454641cc93006f3bce714139aac9ce49ae4cb8/pkg_ext-0.4.0.tar.gz", hash = "sha256:ff91f82573a3ae7cd6f107a7064a3cc5e51cbd798b9a21d9fce0f41611d01ff7", size = 77571, upload-time = "2026-02-24T23:40:00.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/66/896027b6f2158c1fba04acf8e72ba027e9ea4997c2c7dc3f67e6c78ff00b/pkg_ext-0.4.1.tar.gz", hash = "sha256:2a6233385e0720195097d7733e247f586c10d79a7310fa14a8f04735292688b0", size = 77545, upload-time = "2026-02-25T10:59:47.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/49/dc1e42b27cb386fc355eacf24ce5bce4212306cdf4836c9453ced4367731/pkg_ext-0.4.0-py3-none-any.whl", hash = "sha256:89065e52e243a86e4bc7dbcce8b217ceec165f6bcba11b90ccec343a7c38da95", size = 112099, upload-time = "2026-02-24T23:39:58.956Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/a27227715cdb66ab3b0ff7a35a27dec8b9cf2e522f6210ccc31984726fe7/pkg_ext-0.4.1-py3-none-any.whl", hash = "sha256:01e5de39d98ef8e1b74f049a572cb330d80b022e5c43c39c5e4426357480398e", size = 112010, upload-time = "2026-02-25T10:59:45.804Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated dependency update.

## Command Output

```
Processing path-sync...
Cloning https://github.com/EspenAlbert/path-sync to /tmp/path-sync-deps/path-sync
Fetching origin
Checking out main
Creating fresh branch: deps/uv-lock-update
Running: uv -n lock --upgrade
[uv] Using CPython 3.14.0
[uv] Resolved 67 packages in 1.65s
[uv] Updated pkg-ext v0.4.0 -> v0.4.1
Committed: chore(deps): update uv.lock
Running: uv sync
[uv] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
[uv] Using CPython 3.14.0
[uv] Creating virtual environment at: .venv
[uv] Resolved 67 packages in 1ms
[uv]    Building path-sync @ file:///private/tmp/path-sync-deps/path-sync
[uv]       Built path-sync @ file:///private/tmp/path-sync-deps/path-sync
[uv] Prepared 1 package in 283ms
[uv] Installed 32 packages in 165ms
[uv]  + annotated-doc==0.0.4
[uv]  + annotated-types==0.7.0
[uv]  + click==8.3.1
[uv]  + coverage==7.13.4
[uv]  + gitdb==4.0.12
[uv]  + gitpython==3.1.46
[uv]  + iniconfig==2.3.0
[uv]  + markdown-it-py==4.0.0
[uv]  + mdurl==0.1.2
[uv]  + nodeenv==1.10.0
[uv]  + packaging==26.0
[uv]  + path-sync==0.7.6 (from file:///private/tmp/path-sync-deps/path-sync)
[uv]  + pluggy==1.6.0
[uv]  + pydantic==2.12.5
[uv]  + pydantic-core==2.41.5
[uv]  + pygments==2.19.2
[uv]  + pyright==1.1.408
[uv]  + pytest==9.0.2
[uv]  + pytest-asyncio==1.3.0
[uv]  + pytest-cov==7.0.0
[uv]  + pytest-datadir==1.8.0
[uv]  + pytest-regressions==2.10.0
[uv]  + pyyaml==6.0.3
[uv]  + rich==14.3.3
[uv]  + ruff==0.15.2
[uv]  + shellingham==1.5.4
[uv]  + smmap==5.0.2
[uv]  + typer==0.24.1
[uv]  + typing-extensions==4.15.0
[uv]  + typing-inspection==0.4.2
[uv]  + vulture==2.14
[uv]  + zero-3rdparty==0.104.4
Running: just fmt
[just] 39 files left unchanged
[just] uv run ruff format .
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Running: just test
[just] ============================= test session starts ==============================
[just] platform darwin -- Python 3.14.0, pytest-9.0.2, pluggy-1.6.0 -- /private/tmp/path-sync-deps/path-sync/.venv/bin/python
[just] cachedir: .pytest_cache
[just] rootdir: /private/tmp/path-sync-deps/path-sync
[just] configfile: pyproject.toml
[just] plugins: regressions-2.10.0, datadir-1.8.0, asyncio-1.3.0, cov-7.0.0
[just] asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
[just] collecting ... collected 111 items
[just] 
[just] path_sync/_internal/auto_merge_test.py::test_enable_auto_merge_calls_gh 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:84   https://github.com/o/r/pull/1: enabled auto-merge (rebase)
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_get_pr_checks_parses_json PASSED
[just] path_sync/_internal/auto_merge_test.py::test_get_pr_state_returns_merged PASSED
[just] path_sync/_internal/auto_merge_test.py::test_handle_auto_merge_no_wait_skips_polling 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:151 
[just] ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:152  Auto-merge
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:153 ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:165   --no-wait: skipping merge polling
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_handle_auto_merge_skips_already_merged 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:151 
[just] ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:152  Auto-merge
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:153 ────────────────────────────────────────
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:159   repo1: already merged
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:165   --no-wait: skipping merge polling
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_pr_merge_result_failed_and_pending_checks PASSED
[just] path_sync/_internal/auto_merge_test.py::test_log_summary_formats_table 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:184 Repo   PR  State    Failed Checks
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:185 ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:188 repo1    MERGED   
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:188 repo2    OPEN     lint
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_wait_for_merge_timeout 
[just] -------------------------------- live log call ---------------------------------
[just] WARNING  path_sync._internal.auto_merge:auto_merge.py:135 Timeout waiting for myrepo after 0s (https://github.com/o/r/pull/1)
[just] PASSED
[just] path_sync/_internal/auto_merge_test.py::test_wait_for_merge_merged 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.auto_merge:auto_merge.py:123 repo1: merged (https://github.com/o/r/pull/1)
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_no_changes_skips 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:166 test-repo: No changes, skipping
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_update_fails_returns_skipped 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] WARNING  path_sync._internal.cmd_dep_update:cmd_dep_update.py:162 test-repo: Update failed with exit code 1
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_changes_with_skip_verify_passes 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_process_single_repo_verify_runs_when_changes_present 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_run_updates_success_returns_none PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_run_updates_failure_returns_step_failure PASSED
[just] path_sync/_internal/cmd_dep_update_test.py::test_update_and_validate_keeps_pr_when_config_flag_set 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:156 Processing test-repo...
[just] INFO     path_sync._internal.cmd_dep_update:cmd_dep_update.py:166 test-repo: No changes, skipping
[just] PASSED
[just] path_sync/_internal/log_capture_test.py::test_capture_log_captures_logger_output 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync.test:log_capture_test.py:12 first message
[just] INFO     path_sync.test:log_capture_test.py:13 second message
[just] PASSED
[just] path_sync/_internal/log_capture_test.py::test_capture_log_read_after_flush_includes_all 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync.test2:log_capture_test.py:24 before flush
[just] INFO     path_sync.test2:log_capture_test.py:26 after first read
[just] PASSED
[just] path_sync/_internal/models_dep_test.py::test_dep_config_parsing PASSED
[just] path_sync/_internal/models_dep_test.py::test_dep_config_from_yaml PASSED
[just] path_sync/_internal/models_dep_test.py::test_resolve_dep_config_path PASSED
[just] path_sync/_internal/models_dep_test.py::test_load_destinations_with_include_filter PASSED
[just] path_sync/_internal/models_dep_test.py::test_load_destinations_with_exclude_filter PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_no_groups PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_with_groups PASSED
[just] path_sync/_internal/models_test.py::test_resolve_paths_multiple_groups PASSED
[just] path_sync/_internal/models_test.py::test_validation_rejects_unknown_group PASSED
[just] path_sync/_internal/models_test.py::test_validation_rejects_duplicate_group PASSED
[just] path_sync/_internal/models_test.py::test_parse_sync_metadata_from_default_template PASSED
[just] path_sync/_internal/models_test.py::test_parse_sync_metadata_missing PASSED
[just] path_sync/_internal/models_test.py::test_format_body_includes_metadata PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_newer_skips PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_equal_skips PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_older_proceeds PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_no_body PASSED
[just] path_sync/_internal/models_test.py::test_pr_already_synced_no_metadata PASSED
[just] path_sync/_internal/models_test.py::test_format_body_roundtrip_custom_template PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_work_dir PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_relative PASSED
[just] path_sync/_internal/repo_utils_test.py::test_resolve_repo_path_no_relative_no_workdir PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_clones_when_missing PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_dry_run_raises_when_missing PASSED
[just] path_sync/_internal/repo_utils_test.py::test_ensure_repo_returns_existing PASSED
[just] path_sync/cmd_copy_test.py::test_sync_single_file 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_sync_single_file0/dest/out.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_skips_opted_out_file 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:505 Skipping /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_sync_skips_opted_out_file0/dest/file.py (header removed - opted out)
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_force_overwrite_adds_header_when_content_matches 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_force_overwrite_adds_head0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_cleanup_orphans 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:567 Deleted orphan: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_cleanup_orphans0/dest/orphan.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_with_sections_replaces_managed 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_sync_with_sections_replac0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_with_sections_skip PASSED
[just] path_sync/cmd_copy_test.py::test_ensure_repo_dry_run_errors_if_missing PASSED
[just] path_sync/cmd_copy_test.py::test_copy_options_defaults PASSED
[just] path_sync/cmd_copy_test.py::test_source_with_header_no_duplicate 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_source_with_header_no_dup0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_replace_no_header 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_file_mode_replace_no_head0/dest/LICENSE
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_replace_skips_unchanged PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_scaffold_creates_new 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_file_mode_scaffold_create0/dest/.gitignore
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_mode_scaffold_skips_existing PASSED
[just] path_sync/cmd_copy_test.py::test_sync_new_file_respects_skip_sections 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_sync_new_file_respects_sk0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_steps_empty_returns_passed PASSED
[just] path_sync/cmd_copy_test.py::test_verify_steps_all_pass 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo hello
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] hello
[just] INFO     path_sync._internal.verify:verify.py:41 Running: true
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_skip_strategy 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_fail_strategy 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_fails_with_warn_strategy_continues 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo after-warn
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] after-warn
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_step_with_commit_stages_and_commits 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: echo format
[just] INFO     path_sync._internal.verify:verify.py:45 [echo] format
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_verify_per_step_on_fail_overrides_verify_level 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.verify:verify.py:41 Running: false
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrap_synced_files_wraps_content_in_section 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_wrap_synced_files_wraps_c0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrap_per_path_override_disables 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_wrap_per_path_override_di0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_wrapped_file_preserves_dest_content_around_section 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_wrapped_file_preserves_de0/dest/file.py
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_file_with_existing_sections_not_double_wrapped 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_file_with_existing_sectio0/dest/file.sh
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_sync_preserves_dest_trailing_when_adding_new_sections 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:519 Wrote: /private/var/folders/vz/xd9kxc6j17z3ys_mg65s9k0m0000gp/T/pytest-of-espen.albert/pytest-9/test_sync_preserves_dest_trail0/dest/justfile
[just] PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_skipped_when_keep_pr_on_no_changes PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_skipped_when_skip_commit PASSED
[just] path_sync/cmd_copy_test.py::test_close_stale_pr_runs_by_default PASSED
[just] path_sync/cmd_copy_test.py::test_skip_already_synced_bypassed_when_force_resync PASSED
[just] path_sync/cmd_copy_test.py::test_skip_already_synced_checks_by_default 
[just] -------------------------------- live log call ---------------------------------
[just] INFO     path_sync._internal.cmd_copy:cmd_copy.py:241 dest: open PR already synced from abc12345 (2099-01-01T00:00:00+00:00 >= 2026-01-01T00:00:00), skipping
[just] PASSED
[just] path_sync/header_test.py::test_header_generation PASSED
[just] path_sync/header_test.py::test_has_header_matches_any_config_name PASSED
[just] path_sync/header_test.py::test_add_remove_header PASSED
[just] path_sync/header_test.py::test_add_header_extensionless PASSED
[just] path_sync/header_test.py::test_file_has_header PASSED
[just] path_sync/models_test.py::test_path_mapping_resolved PASSED
[just] path_sync/models_test.py::test_resolve_config_path PASSED
[just] path_sync/models_test.py::test_find_repo_root PASSED
[just] path_sync/models_test.py::test_src_config_find_destination PASSED
[just] path_sync/models_test.py::test_destination_skip_sections PASSED
[just] path_sync/models_test.py::test_destination_skip_file_patterns PASSED
[just] path_sync/models_test.py::test_pr_defaults_format_body PASSED
[just] path_sync/models_test.py::test_pr_defaults_format_body_extracts_repo_name PASSED
[just] path_sync/models_test.py::test_path_mapping_is_excluded PASSED
[just] path_sync/models_test.py::test_destination_resolve_verify PASSED
[just] path_sync/sections_test.py::test_parse_sections PASSED
[just] path_sync/sections_test.py::test_parse_sections_no_markers PASSED
[just] path_sync/sections_test.py::test_parse_sections_nested_error PASSED
[just] path_sync/sections_test.py::test_parse_sections_unclosed_error PASSED
[just] path_sync/sections_test.py::test_parse_sections_standalone_ok_edit PASSED
[just] path_sync/sections_test.py::test_has_sections PASSED
[just] path_sync/sections_test.py::test_wrap_in_default_section PASSED
[just] path_sync/sections_test.py::test_parse_sections_content PASSED
[just] path_sync/sections_test.py::test_replace_sections_updates_content PASSED
[just] path_sync/sections_test.py::test_replace_sections_preserves_ok_edit PASSED
[just] path_sync/sections_test.py::test_replace_sections_skip PASSED
[just] path_sync/sections_test.py::test_replace_sections_adds_new PASSED
[just] path_sync/sections_test.py::test_replace_sections_keeps_dest_only PASSED
[just] path_sync/sections_test.py::test_markdown_sections PASSED
[just] path_sync/sections_test.py::test_parse_resumable_section PASSED
[just] path_sync/sections_test.py::test_replace_resumable_section_preserves_user_content PASSED
[just] path_sync/validation_test.py::test_modify_ok_edit_passes PASSED
[just] path_sync/validation_test.py::test_modify_do_not_edit_fails PASSED
[just] path_sync/validation_test.py::test_skip_section_passes PASSED
[just] path_sync/validation_test.py::test_section_removed_warns_not_fails 
[just] -------------------------------- live log call ---------------------------------
[just] WARNING  path_sync._internal.validation:validation.py:61 Section 'standard' removed from test.py, consider updating src.yaml
[just] PASSED
[just] path_sync/validation_test.py::test_no_sections_full_file_comparison PASSED
[just] path_sync/validation_test.py::test_parse_skip_sections PASSED
[just] 
[just] ============================= 111 passed in 2.03s ==============================
[just] uv run pytest
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Running: just pkg-pre-change --full
[just] [11:23:47] INFO     ✅ '/opt/homebrew/bin/gh api user --jq .login' completed in 0.61s                                                                                                                                                                                                                                              rich_progress.py:51
[just]            WARNING  Symbol moved: _internal.models_dep.OnFailStrategy -> _internal.models.OnFailStrategy (group: dep_update)                                                                                                                                                                                                             groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyConfig -> _internal.models.VerifyConfig (group: dep_update)                                                                                                                                                                                                                 groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.CommitConfig -> _internal.models.CommitConfig (group: dep_update)                                                                                                                                                                                                                 groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyStep -> _internal.models.VerifyStep (group: dep_update)                                                                                                                                                                                                                     groups.py:166
[just] [11:23:48] INFO     ✅ '/opt/homebrew/bin/gh pr view --json baseRefName,url,baseRefOid' completed in 0.83s                                                                                                                                                                                                                         rich_progress.py:51
[just]            INFO     No removed references found in the package                                                                                                                                                                                                                                                                           removed.py:48
[just]            INFO     ✅ New References expose/hide decisions completed in 0.00s                                                                                                                                                                                                                                                     rich_progress.py:51
[just]            WARNING  no changelog file @ /private/tmp/path-sync-deps/path-sync/.changelog/029.yaml                                                                                                                                                                                                                                       actions.py:362
[just]            WARNING  no changelog file @ /private/tmp/path-sync-deps/path-sync/.changelog/029.yaml                                                                                                                                                                                                                                       actions.py:362
[just]            WARNING  Symbol moved: _internal.models_dep.OnFailStrategy -> _internal.models.OnFailStrategy (group: dep_update)                                                                                                                                                                                                             groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyConfig -> _internal.models.VerifyConfig (group: dep_update)                                                                                                                                                                                                                 groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.CommitConfig -> _internal.models.CommitConfig (group: dep_update)                                                                                                                                                                                                                 groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyStep -> _internal.models.VerifyStep (group: dep_update)                                                                                                                                                                                                                     groups.py:166
[just]            INFO     API dump written to /private/tmp/path-sync-deps/path-sync/path_sync.api-dev.yaml                                                                                                                                                                                                                                  workflows.py:249
[just] [11:23:49] INFO     No API changes detected                                                                                                                                                                                                                                                                                           workflows.py:269
[just]            WARNING  Symbol moved: _internal.models_dep.OnFailStrategy -> _internal.models.OnFailStrategy (group: dep_update)                                                                                                                                                                                                             groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyConfig -> _internal.models.VerifyConfig (group: dep_update)                                                                                                                                                                                                                 groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.CommitConfig -> _internal.models.CommitConfig (group: dep_update)                                                                                                                                                                                                                 groups.py:166
[just]            WARNING  Symbol moved: _internal.models_dep.VerifyStep -> _internal.models.VerifyStep (group: dep_update)                                                                                                                                                                                                                     groups.py:166
[just]            INFO     Regenerated 18 doc files                                                                                                                                                                                                                                                                                      workflow_cmds.py:200
[just] [11:23:49] You can find the run logs in /Users/espen.albert/code/z_cache/ask_shell/pkg-ext/pre_change/2026-02-25T11-23-47Z                                                                                                                                                                                                         typer_command.py:26
[just]            INFO     ✅ Running: '/private/tmp/path-sync-deps/path-sync/.venv/bin/pkg-ext pre-change --full' completed in 2.15s                                                                                                                                                                                                     rich_progress.py:51
[just] uv run --group release pkg-ext pre-change --full
[just] warning: `VIRTUAL_ENV=/Users/espen.albert/agentws/py-src/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
[just] Installed 11 packages in 11ms
[just] /private/tmp/path-sync-deps/path-sync/.venv/lib/python3.14/site-packages/model_lib/pydantic_utils.py:7: UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
[just]   from pydantic.v1.datetime_parse import parse_datetime
```